### PR TITLE
make it thread-safe

### DIFF
--- a/include/ext4_fs.h
+++ b/include/ext4_fs.h
@@ -67,6 +67,15 @@ struct ext4_fs {
 	struct jbd_fs *jbd_fs;
 	struct jbd_journal *jbd_journal;
 	struct jbd_trans *curr_trans;
+
+	void (*inode_alloc_lock)();
+	void (*inode_alloc_unlock)();
+
+	void (*block_alloc_lock)();
+	void (*block_alloc_unlock)();
+
+	void (*bcache_lock)();
+	void (*bcache_unlock)();
 };
 
 struct ext4_block_group_ref {

--- a/src/ext4_balloc.c
+++ b/src/ext4_balloc.c
@@ -149,7 +149,8 @@ ext4_balloc_verify_bitmap_csum(struct ext4_sblock *sb,
 #define ext4_balloc_verify_bitmap_csum(...) true
 #endif
 
-int ext4_balloc_free_block(struct ext4_inode_ref *inode_ref, ext4_fsblk_t baddr)
+static int
+__ext4_balloc_free_block(struct ext4_inode_ref *inode_ref, ext4_fsblk_t baddr)
 {
 	struct ext4_fs *fs = inode_ref->fs;
 	struct ext4_sblock *sb = &fs->sb;
@@ -223,14 +224,25 @@ int ext4_balloc_free_block(struct ext4_inode_ref *inode_ref, ext4_fsblk_t baddr)
 		ext4_fs_put_block_group_ref(&bg_ref);
 		return rc;
 	}
+	fs->bcache_lock();
 	ext4_bcache_invalidate_lba(fs->bdev->bc, baddr, 1);
+	fs->bcache_unlock();
 	/* Release block group reference */
 	rc = ext4_fs_put_block_group_ref(&bg_ref);
 
 	return rc;
 }
 
-int ext4_balloc_free_blocks(struct ext4_inode_ref *inode_ref,
+int ext4_balloc_free_block(struct ext4_inode_ref *inode_ref, ext4_fsblk_t baddr)
+{
+	inode_ref->fs->block_alloc_lock();
+	int rc = __ext4_balloc_free_block(inode_ref, baddr);
+	inode_ref->fs->block_alloc_unlock();
+	return rc;
+}
+
+static int
+__ext4_balloc_free_blocks(struct ext4_inode_ref *inode_ref,
 			    ext4_fsblk_t first, uint32_t count)
 {
 	int rc = EOK;
@@ -342,14 +354,26 @@ int ext4_balloc_free_blocks(struct ext4_inode_ref *inode_ref,
 
 	}
 
+	fs->bcache_lock();
 	ext4_bcache_invalidate_lba(fs->bdev->bc, start_block, blk_cnt);
+	fs->bcache_unlock();
 	/*All blocks should be released*/
 	ext4_assert(count == 0);
 
 	return rc;
 }
 
-int ext4_balloc_alloc_block(struct ext4_inode_ref *inode_ref,
+int ext4_balloc_free_blocks(struct ext4_inode_ref *inode_ref,
+                          ext4_fsblk_t first, uint32_t count)
+{
+	inode_ref->fs->block_alloc_lock();
+	int rc = __ext4_balloc_free_blocks(inode_ref, first, count);
+	inode_ref->fs->block_alloc_unlock();
+	return rc;
+}
+
+static int
+__ext4_balloc_alloc_block(struct ext4_inode_ref *inode_ref,
 			    ext4_fsblk_t goal,
 			    ext4_fsblk_t *fblock)
 {
@@ -580,6 +604,16 @@ success:
 
 	*fblock = alloc;
 	return r;
+}
+
+int ext4_balloc_alloc_block(struct ext4_inode_ref *inode_ref,
+                        ext4_fsblk_t goal,
+                        ext4_fsblk_t *fblock)
+{
+	inode_ref->fs->block_alloc_lock();
+	int rc = __ext4_balloc_alloc_block(inode_ref, goal, fblock);
+	inode_ref->fs->block_alloc_unlock();
+	return rc;
 }
 
 int ext4_balloc_try_alloc_block(struct ext4_inode_ref *inode_ref,

--- a/src/ext4_fs.c
+++ b/src/ext4_fs.c
@@ -1657,8 +1657,10 @@ int ext4_fs_append_inode_dblk(struct ext4_inode_ref *inode_ref,
 		if (rc != EOK)
 			return rc;
 
-		*fblock = current_fsblk;
-		ext4_assert(*fblock);
+		if (fblock) {
+			*fblock = current_fsblk;
+			ext4_assert(*fblock);
+		}
 
 		ext4_inode_set_size(inode_ref->inode, inode_size + block_size);
 		inode_ref->dirty = true;
@@ -1702,7 +1704,8 @@ int ext4_fs_append_inode_dblk(struct ext4_inode_ref *inode_ref,
 	ext4_inode_set_size(inode_ref->inode, inode_size + block_size);
 	inode_ref->dirty = true;
 
-	*fblock = phys_block;
+	if (fblock)
+		*fblock = phys_block;
 	*iblock = new_block_idx;
 
 	return EOK;

--- a/src/ext4_trans.c
+++ b/src/ext4_trans.c
@@ -68,10 +68,9 @@ int ext4_trans_block_get_noread(struct ext4_blockdev *bdev,
 			  struct ext4_block *b,
 			  uint64_t lba)
 {
+	bdev->fs->bcache_lock();
 	int r = ext4_block_get_noread(bdev, b, lba);
-	if (r != EOK)
-		return r;
-
+	bdev->fs->bcache_unlock();
 	return r;
 }
 


### PR DESCRIPTION
This patch modifies this fork of lwext4 to make is safe to interact with by multiple threads running in OSv.

The key assumption is, that OSv VFS layer provides necessary locking around all interactions with lwext4 to guard ext filesystem metadata (i-node table, directory entries, etc) modifications confined to specific vnode.

Beyond that, we add necessary locking around 3 key common data structures:
- i-node bitmaps in ext4_ialloc.c
- data block bitmaps in ext4_balloc.c
- metadata blockcache in ext4_bcache.c and related files

More specifically following functions are protected with inode_alloc_lock()/unlock() to make sure no two files/directories get assigned same inode number:
- ext4_ialloc_alloc_inode()
- ext4_ialloc_free_inode()

Next, following functions are protected with block_alloc_lock()/unlock() to make sure no two files/directories use same data block:
- ext4_balloc_alloc_block()
- ext4_balloc_free_block()
- ext4_balloc_free_blocks()

Finally, these functions in ext4_bcache.c and related source files are protected with bcache_lock()/unlock() to make sure the global metadata block cache access is synchronized:
- ext4_bcache_invalidate_lba() in __ext4_balloc_free_block() and __ext4_balloc_free_blocks()
- ext4_bcache_find_get(), ext4_block_flush_buf() and ext4_bcache_free() in ext4_block_flush_lba()
- ext4_block_get_noread(), ext4_bcache_test_flag() ext4_bcache_free() in ext4_block_get()
- ext4_bcache_free() in ext4_block_set()
- ext4_block_get_noread() in ext4_trans_block_get_noread()

Ref https://github.com/gkostka/lwext4/issues/83
Ref https://github.com/cloudius-systems/osv/issues/1179